### PR TITLE
nix/package: include rom workspace member in fileset

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,6 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       root = s;
       fileset = fs.unions [
         (s + /crates)
+        (s + /rom)
         (s + /Cargo.lock)
         (s + /Cargo.toml)
       ];


### PR DESCRIPTION
The src fileset only included crates/, Cargo.toml and Cargo.lock, but
the workspace Cargo.toml lists "rom" as a member. This caused
`nix build` to fail with:

  failed to read `/build/source/rom/Cargo.toml`
  No such file or directory
