### PR TITLE
Add `aarch64-darwin` to `systems`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
     self,
     nixpkgs,
   }: let
-    systems = ["x86_64-linux" "aarch64-linux"];
+    systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
     forEachSystem = nixpkgs.lib.genAttrs systems;
 
     pkgsForEach = nixpkgs.legacyPackages;


### PR DESCRIPTION
This lets people like me run `nix shell github:manic-systems/rom` on a MacBook.